### PR TITLE
Website nojekyll fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Deploy Markdown to Website
         uses: peaceiris/actions-gh-pages@v3
         with:
+          enable_jekyll: true
           deploy_key: ${{ secrets.SITE_DEPLOY_KEY }}
           external_repository: engteam14/website2
           publish_branch: main


### PR DESCRIPTION
Prevent deploy to website from causing a nojekyll file to be generated, which breaks the website